### PR TITLE
Fix issue with obfuscated actions/states being the same, bump to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2019-01-07
+### Fixed
+- Use correct hash for obfuscated Actions and States [#3](https://github.com/ww-tech/roxie/pull/3)
 
 ## [0.2.0] - 2019-01-06
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add the following Gradle dependency to your project `build.gradle` file:
 
 ```groovy
 dependencies {
-    implementation 'com.ww:roxie:0.2.0'
+    implementation 'com.ww:roxie:0.2.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
 
     // Roxie Library
     libVersionCode = 2
-    libVersionName = '0.2.0'
+    libVersionName = '0.2.1'
 
     libPomUrl = 'https://github.com/ww-tech/roxie'
     libGithubRepo = 'ww-tech/roxie'

--- a/roxie/build.gradle
+++ b/roxie/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     compileOnly 'android.arch.lifecycle:extensions:1.1.1'
 
     compileOnly "io.reactivex.rxjava2:rxjava:$rootProject.ext.rxJavaVersion"
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.amshove.kluent:kluent:1.45'
 }
 
 // applied specifically at the bottom

--- a/roxie/src/main/kotlin/com/ww/roxie/BaseAction.kt
+++ b/roxie/src/main/kotlin/com/ww/roxie/BaseAction.kt
@@ -26,5 +26,5 @@ interface BaseAction {
      *
      * Useful for hiding sensitive information when logging actions.
      */
-    fun obfuscatedString() = "${javaClass.simpleName}@${javaClass.hashCode()}"
+    fun obfuscatedString() = "${javaClass.simpleName}@${hashCode()}"
 }

--- a/roxie/src/main/kotlin/com/ww/roxie/BaseState.kt
+++ b/roxie/src/main/kotlin/com/ww/roxie/BaseState.kt
@@ -26,5 +26,5 @@ interface BaseState {
      *
      * Useful for hiding sensitive information when logging states.
      */
-    fun obfuscatedString() = "${javaClass.simpleName}@${javaClass.hashCode()}"
+    fun obfuscatedString() = "${javaClass.simpleName}@${hashCode()}"
 }

--- a/roxie/src/test/java/com/ww/roxie/BaseActionTest.kt
+++ b/roxie/src/test/java/com/ww/roxie/BaseActionTest.kt
@@ -1,0 +1,53 @@
+/*
+* Copyright (C) 2019. WW International, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.ww.roxie
+
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.amshove.kluent.shouldNotContain
+import org.junit.Test
+
+class BaseActionTest {
+
+    @Test
+    fun `Given obfuscated action with data, when to string, then to string returns obfuscated string without data`() {
+        // GIVEN
+        val data = "test"
+
+        // WHEN
+        val result = ObfuscatedAction(data).toString()
+
+        // THEN
+        result shouldNotContain data
+    }
+
+    @Test
+    fun `Given two obfuscated actions with different data, when to string, then actions have different obfuscated strings`() {
+        // GIVEN
+        val actionOne = ObfuscatedAction("test")
+        val actionTwo = ObfuscatedAction("test2")
+
+        // WHEN
+        val resultOne = actionOne.toString()
+        val resultTwo = actionTwo.toString()
+
+        // THEN
+        resultOne shouldNotBeEqualTo resultTwo
+    }
+}
+
+private data class ObfuscatedAction(val data: String) : BaseAction {
+    override fun toString(): String = obfuscatedString()
+}

--- a/roxie/src/test/java/com/ww/roxie/BaseStateTest.kt
+++ b/roxie/src/test/java/com/ww/roxie/BaseStateTest.kt
@@ -1,0 +1,53 @@
+/*
+* Copyright (C) 2019. WW International, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.ww.roxie
+
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.amshove.kluent.shouldNotContain
+import org.junit.Test
+
+class BaseStateTest {
+
+    @Test
+    fun `Given obfuscated state with data, when to string, then to string returns obfuscated string without data`() {
+        // GIVEN
+        val data = "test"
+
+        // WHEN
+        val result = ObfuscatedState(data).toString()
+
+        // THEN
+        result shouldNotContain data
+    }
+
+    @Test
+    fun `Given two obfuscated states with different data, when to string, then states have different obfuscated strings`() {
+        // GIVEN
+        val stateOne = ObfuscatedState("test")
+        val stateTwo = ObfuscatedState("test2")
+
+        // WHEN
+        val resultOne = stateOne.toString()
+        val resultTwo = stateTwo.toString()
+
+        // THEN
+        resultOne shouldNotBeEqualTo resultTwo
+    }
+}
+
+private data class ObfuscatedState(val data: String) : BaseState {
+    override fun toString(): String = obfuscatedString()
+}


### PR DESCRIPTION
### Fix issue with obfuscated actions/states being the same regardless of data.
Issue was due to the hash coding occurring on the class name instead of
the actual object.

Obfuscation only really applies to `data class`es since kotlin gives us a `toString` 
that contains the class' data (printing a normal `class` will output something 
similar to our obfuscated strings).

### Sample (where comment indicates print result)
Without obfuscating:
```kotlin
data class ObfuscatedAction(val data: String) : BaseAction
print(ObfuscatedAction(data="test")) // ObfuscatedAction(data=test)
```
With obfuscating:
```kotlin
data class ObfuscatedAction(val data: String) : BaseAction {
    override fun toString() = obfuscatedString()
}
print(ObfuscatedAction(data="test")) // ObfuscatedAction@123 -  where 123 is the hash code.
```

### More Stuff
Bump to `0.2.1` with fixes.
Add kluent to make our tests prettier.